### PR TITLE
Render player names larger and with black outline

### DIFF
--- a/scenes/Jumper.tres
+++ b/scenes/Jumper.tres
@@ -1,0 +1,20 @@
+[gd_resource type="Theme" format=3 uid="uid://nfhtrrji7j2u"]
+
+[resource]
+RichTextLabel/colors/default_color = Color(1, 1, 1, 1)
+RichTextLabel/colors/font_outline_color = Color(0, 0, 0, 1)
+RichTextLabel/colors/font_selected_color = Color(0, 0, 0, 0)
+RichTextLabel/colors/font_shadow_color = Color(0, 0, 0, 0)
+RichTextLabel/colors/selection_color = Color(0.1, 0.1, 1, 0.8)
+RichTextLabel/colors/table_border = Color(0, 0, 0, 0)
+RichTextLabel/colors/table_even_row_bg = Color(0, 0, 0, 0)
+RichTextLabel/colors/table_odd_row_bg = Color(0, 0, 0, 0)
+RichTextLabel/constants/line_separation = 0
+RichTextLabel/constants/outline_size = 40
+RichTextLabel/constants/shadow_offset_x = 0
+RichTextLabel/constants/shadow_offset_y = 0
+RichTextLabel/constants/shadow_outline_size = 0
+RichTextLabel/constants/table_h_separation = 0
+RichTextLabel/constants/table_v_separation = 0
+RichTextLabel/constants/text_highlight_h_padding = 0
+RichTextLabel/constants/text_highlight_v_padding = 0

--- a/scenes/Jumper.tscn
+++ b/scenes/Jumper.tscn
@@ -15,6 +15,7 @@
 [ext_resource type="Texture2D" uid="uid://dn80vo65nle0y" path="res://assets/sprites/characters/Male/Character 1/Clothes 1/Character1M_1_jump_1.png" id="10_ac3fu"]
 [ext_resource type="Texture2D" uid="uid://cr7baxkpawx43" path="res://assets/sprites/characters/Male/Character 1/Clothes 1/Character1M_1_land_0.png" id="11_3fxgy"]
 [ext_resource type="Texture2D" uid="uid://de5vceaa85fe0" path="res://assets/sprites/characters/Male/Character 1/Clothes 1/Character1M_1_land_1.png" id="12_bwbvy"]
+[ext_resource type="Theme" uid="uid://nfhtrrji7j2u" path="res://scenes/Jumper.tres" id="16_fsbtc"]
 
 [sub_resource type="SpriteFrames" id="SpriteFrames_1dd66"]
 animations = [{
@@ -84,9 +85,6 @@ animations = [{
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_6u5om"]
 size = Vector2(14, 26)
 
-[sub_resource type="LabelSettings" id="LabelSettings_wa6ai"]
-font_size = 10
-
 [node name="Jumper" type="CharacterBody2D"]
 collision_layer = 2
 script = ExtResource("1_jn4ug")
@@ -115,11 +113,18 @@ autoplay = "idle"
 position = Vector2(0, -13)
 shape = SubResource("RectangleShape2D_6u5om")
 
-[node name="Name" type="Label" parent="."]
-offset_left = -115.0
-offset_top = -45.0
-offset_right = 116.0
-offset_bottom = -30.0
-text = "Name"
-label_settings = SubResource("LabelSettings_wa6ai")
-horizontal_alignment = 1
+[node name="Node2D" type="Node2D" parent="."]
+position = Vector2(0, -55)
+scale = Vector2(0.3, 0.3)
+
+[node name="Name" type="RichTextLabel" parent="Node2D"]
+texture_filter = 2
+offset_left = -1328.0
+offset_top = -46.0
+offset_right = 1328.0
+offset_bottom = 115.0
+theme = ExtResource("16_fsbtc")
+theme_override_font_sizes/normal_font_size = 100
+bbcode_enabled = true
+text = "[center]Name New[/center]"
+scroll_active = false

--- a/src/Jumper.cs
+++ b/src/Jumper.cs
@@ -4,7 +4,7 @@ using Godot;
 public partial class Jumper : CharacterBody2D
 {
     private const string SpriteNodeName = "Sprite";
-    private const string NameNodeName = "Name";
+    private const string NameNodeName = "Node2D/Name";
     private const string ParticleSystemNodeName = "Glow";
     private bool _wasOnFloor = false;
 
@@ -20,7 +20,7 @@ public partial class Jumper : CharacterBody2D
         Position = new Vector2(x, y);
         Name = userName;
         this.playerData = playerData;
-        GetNode<Label>(NameNodeName).Text = userName;
+        GetNode<RichTextLabel>(NameNodeName).Text = "[center]" + userName + "[/center]";
 
         SetCharacter(playerData.CharacterChoice);
 


### PR DESCRIPTION
* Renders the player name bigger
* Uses a RichTextLabel instead of a Label
* Give the font a black outline

New font rendering with outline and much bigger:
<img width="150" alt="new name with outline" src="https://github.com/AdamLearns/JumpRoyale/assets/1223335/6cbf05eb-f09d-4370-be3a-e39ea7fa856c">

Old font rendering:
<img width="81" alt="old name" src="https://github.com/AdamLearns/JumpRoyale/assets/1223335/4f772c45-64f9-49a3-bc14-82f20bb61f8a">

(New) 2 names overlapping ("smu4242bot" and "smu4242"):
<img width="280" alt="overlapping" src="https://github.com/AdamLearns/JumpRoyale/assets/1223335/71e4236a-ca9c-4743-8d1c-134e3410d3e3">

This tackles one item from https://github.com/AdamLearns/JumpRoyale/issues/14
