### PR TITLE
Allow shorter "lru" commands without spaces

### DIFF
--- a/src/Arena.cs
+++ b/src/Arena.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using Godot;
 using TwitchChat;
 using TwitchLib.PubSub.Events;
@@ -450,6 +451,7 @@ public partial class Arena : Node2D
 
     private void OnMessage(object sender, MessageEventArgs e)
     {
+        Regex regex = new Regex(@"^[rlu][-]?\d");
         var lowercaseMessage = e.Message.ToLower();
         if (lowercaseMessage.StartsWith("join"))
         {
@@ -481,6 +483,7 @@ public partial class Arena : Node2D
             || lowercaseMessage.Equals("ul")
             || lowercaseMessage.StartsWith("ur ")
             || lowercaseMessage.Equals("ur")
+            || regex.IsMatch(lowercaseMessage)
         )
         {
             /// Warning: the above list only exists until a List.Any is implemented for the check

--- a/src/Commands/BaseChatCommand.cs
+++ b/src/Commands/BaseChatCommand.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 /// <summary>
 /// Base class for chat commands that provide command name and argument storage. Commands
@@ -18,9 +19,60 @@ public abstract class BaseChatCommand
 
     public BaseChatCommand(string chatMessage)
     {
-        arguments = chatMessage.Split(" ", StringSplitOptions.RemoveEmptyEntries);
+        arguments = splitArguments(chatMessage);
 
         Name = arguments[0].ToLower();
+    }
+
+    // split arguments, e.g. make "r-12" into ["r", "-12"]
+    public static string[] splitArguments(string chatMessage)
+    {
+        List<string> result = new();
+        string tmpWord = "";
+        bool wasLetter = false;
+        bool wasDigit = false;
+
+        foreach (char c in chatMessage)
+        {
+            if (char.IsLetter(c))
+            {
+                if (wasDigit)
+                {
+                    result.Add(tmpWord);
+                    tmpWord = "";
+                }
+                tmpWord += c;
+                wasLetter = true;
+                wasDigit = false;
+            }
+            else if (char.IsDigit(c) || c == '-')
+            {
+                if (wasLetter)
+                {
+                    result.Add(tmpWord);
+                    tmpWord = "";
+                }
+                tmpWord += c;
+                wasDigit = true;
+                wasLetter = false;
+            }
+            else
+            {
+                if (wasLetter || wasDigit)
+                {
+                    result.Add(tmpWord);
+                    tmpWord = "";
+                }
+                wasDigit = false;
+                wasLetter = false;
+            }
+        }
+
+        if (!string.IsNullOrEmpty(tmpWord))
+        {
+            result.Add(tmpWord);
+        }
+        return result.ToArray();
     }
 
     /// <summary>


### PR DESCRIPTION
This allows commands like
* "r45" additional to "r 45"
* "u10" additional to "u 10"
* "l-10" additional to "l -10"


This tackles one item from https://github.com/AdamLearns/JumpRoyale/issues/14
