### PR TITLE
Limit game fps to 60

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -13,6 +13,7 @@ config_version=5
 config/name="Jump Royale"
 run/main_scene="res://scenes/Arena.tscn"
 config/features=PackedStringArray("4.2", "C#", "Forward Plus")
+run/max_fps=60
 config/icon="res://assets/sprites/icon.svg"
 
 [display]


### PR DESCRIPTION
Let's use the template 😏 

**Describe the pull request**

This PR limits fps to 60, it doesn't need to process thousands of frames.

**Why**

The game runs on maximum possible fps on the current machine, which results in unnecessary resource consumption. Since it's a streaming game, it takes the extra load off GPU *if* you use GPU encoding.

**How**

Overrides the default project settings by limiting the frames per second to 60

**Screenshots**

![img](https://github.com/AdamLearns/JumpRoyale/assets/7021295/73e8ae05-6428-416a-bff1-18b729ec02c3)

More screenshots available in issue #19 

---

Closes #19