### PR TITLE
Match Prettier formatting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,9 @@
         "editor.defaultFormatter": "csharpier.csharpier-vscode",
         "editor.formatOnSave": true,
         "editor.rulers": [120]
+    },
+    "markdownlint.config": {
+        "ul-indent": { "indent": 4 },
+        "list-marker-space": { "ul_single": 3, "ol_multi": 3, "ol_single": 3, "ul_multi": 3 }
     }
 }


### PR DESCRIPTION
After the recent *small* formatting clash inside the README, I adjusted the `markdownlint` config for those, who use this extension. Fortunately, it was just a small difference between `Prettier`'s formatting, and everything seems to be fine now.

Just in case I formatted some nested list with both Prettier and Markdown lint and the outputs are the same. Not sure if Prettier's formatting is like that by default and if that's something we can configure, but it doesn't really matter. People use `Markdownlint` mostly as analyzers for consistency, but the formatting can still be forced with Prettier, which we could also add to the settings if more collisions occur.

```md
-   something
    -   something
        -   something
            -   something
        -   something
```

---

Closes #54 