### PR TITLE
Fixes the font being too big for winners

### DIFF
--- a/JumpRoyale/scenes/Jumper.tscn
+++ b/JumpRoyale/scenes/Jumper.tscn
@@ -116,9 +116,9 @@ shape = SubResource("RectangleShape2D_6u5om")
 [node name="Name" type="RichTextLabel" parent="."]
 texture_filter = 2
 offset_left = -1328.0
-offset_top = -69.0
+offset_top = -61.0
 offset_right = 1328.0
-offset_bottom = 85.0
+offset_bottom = 93.0
 theme = ExtResource("16_fsbtc")
 theme_override_font_sizes/normal_font_size = 24
 bbcode_enabled = true

--- a/JumpRoyale/src/Arena.cs
+++ b/JumpRoyale/src/Arena.cs
@@ -538,7 +538,8 @@ public partial class Arena : Node2D
             }
 #pragma warning restore S2583 // Conditionally executed code should be reachable
 
-            int scale = 3 + 1 - i;
+            // Make the winners much bigger
+            int scale = Math.Max(2, 4 - i);
 
             jumper.Position = new Vector2(tileX * _tileSetToUse.TileSize.X, 50);
             jumper.Scale = new Vector2(scale, scale);

--- a/JumpRoyale/src/Arena.cs
+++ b/JumpRoyale/src/Arena.cs
@@ -538,7 +538,7 @@ public partial class Arena : Node2D
             }
 #pragma warning restore S2583 // Conditionally executed code should be reachable
 
-            int scale = winners.Length + 1 - i;
+            int scale = 3 + 1 - i;
 
             jumper.Position = new Vector2(tileX * _tileSetToUse.TileSize.X, 50);
             jumper.Scale = new Vector2(scale, scale);


### PR DESCRIPTION
This also makes the font size independent of the number of winners/players

<img width="565" alt="Godot_v4 2 1-stable_mono_win64_hZNlqqSgoo" src="https://github.com/AdamLearns/JumpRoyale/assets/1223335/1c725f44-c81f-453a-9d0c-4504fd36da9e">


This fixes https://github.com/AdamLearns/JumpRoyale/issues/49