### PR TITLE
Small .NET 8.0 adjustments

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -111,6 +111,8 @@ dotnet_diagnostic.CA2213.severity = none
 dotnet_diagnostic.CA2201.severity = none
 # Match nullability of reference types in Delegates
 dotnet_diagnostic.CS8622.severity = none
+# Don't re-use primary constructor parameters
+dotnet_diagnostic.CS9124.severity = error
 
 # New line preferences
 csharp_new_line_before_open_brace = all

--- a/.editorconfig
+++ b/.editorconfig
@@ -32,7 +32,7 @@ dotnet_diagnostic.SA1000.severity = none
 # -- should not show this warning for multi-line constructors
 dotnet_diagnostic.SA1009.severity = none
 # Opening square brackets should not be preceded by a space
-# This is a C#12 specific
+# This is a C#12 specific issue related to formatters not being able to format collection expressions
 dotnet_diagnostic.SA1010.severity = none
 # Prefix local calls with `this`
 dotnet_diagnostic.SA1101.severity = none

--- a/.editorconfig
+++ b/.editorconfig
@@ -84,6 +84,8 @@ dotnet_diagnostic.S3903.severity = none
 dotnet_diagnostic.IDE0005.severity = warning
 # Ignore s_ prefixes
 dotnet_diagnostic.IDE1006.severity = none
+# Ignore collection initializers
+dotnet_diagnostic.IDE0028.severity = none
 # 'new' expression can be simplified
 dotnet_diagnostic.IDE0090.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -31,6 +31,9 @@ dotnet_diagnostic.SA1000.severity = none
 # Ignore cases for closing parenthesis being on new line
 # -- should not show this warning for multi-line constructors
 dotnet_diagnostic.SA1009.severity = none
+# Opening square brackets should not be preceded by a space
+# This is a C#12 specific
+dotnet_diagnostic.SA1010.severity = none
 # Prefix local calls with `this`
 dotnet_diagnostic.SA1101.severity = none
 # Do not prefix local calls with `this`
@@ -84,8 +87,6 @@ dotnet_diagnostic.S3903.severity = none
 dotnet_diagnostic.IDE0005.severity = warning
 # Ignore s_ prefixes
 dotnet_diagnostic.IDE1006.severity = none
-# Ignore collection initializers
-dotnet_diagnostic.IDE0028.severity = none
 # 'new' expression can be simplified
 dotnet_diagnostic.IDE0090.severity = warning
 

--- a/JumpRoyale/src/AllPlayerData.cs
+++ b/JumpRoyale/src/AllPlayerData.cs
@@ -5,6 +5,6 @@ public class AllPlayerData
 {
 #pragma warning disable CA2227 // Collection properties should be read only
     [JsonPropertyName("players")]
-    public Dictionary<string, PlayerData> Players { get; set; } = new();
+    public Dictionary<string, PlayerData> Players { get; set; } = [];
 #pragma warning restore CA2227 // Collection properties should be read only
 }

--- a/JumpRoyale/src/Arena.cs
+++ b/JumpRoyale/src/Arena.cs
@@ -694,7 +694,7 @@ public partial class Arena : Node2D
         {
             Jumper jumper = jumpersEntry.Value;
 
-            if (!jumper.PlayerData.Name.Equals(displayName))
+            if (!jumper.PlayerData.Name.Equals(displayName, StringComparison.CurrentCultureIgnoreCase))
             {
                 continue;
             }

--- a/JumpRoyale/src/Arena.cs
+++ b/JumpRoyale/src/Arena.cs
@@ -20,7 +20,7 @@ public partial class Arena : Node2D
     private const string CanvasLayerNodeName = "CanvasLayer";
     private const string SaveLocation = "res://save_data/players.json";
 
-    private readonly Dictionary<string, Jumper> _jumpers = new();
+    private readonly Dictionary<string, Jumper> _jumpers = [];
     private AllPlayerData _allPlayerData = new();
     private TileMap _lobbyTilemap = new();
     private RandomNumberGenerator _rng = new();

--- a/JumpRoyale/src/Arena.cs
+++ b/JumpRoyale/src/Arena.cs
@@ -158,8 +158,8 @@ public partial class Arena : Node2D
 
         int randomCharacterChoice = _rng.RandiRange(1, 18);
 
-        PlayerData playerData = _allPlayerData.Players.ContainsKey(userId)
-            ? _allPlayerData.Players[userId]
+        PlayerData playerData = _allPlayerData.Players.TryGetValue(userId, out PlayerData? value)
+            ? value
             : new PlayerData(hexColor, randomCharacterChoice);
 
         _allPlayerData.Players[userId] = playerData;
@@ -684,7 +684,7 @@ public partial class Arena : Node2D
         {
             Jumper jumper = jumpersEntry.Value;
 
-            if (jumper.PlayerData.Name.ToLower() != displayName.ToLower())
+            if (!jumper.PlayerData.Name.Equals(displayName, StringComparison.CurrentCultureIgnoreCase))
             {
                 continue;
             }

--- a/JumpRoyale/src/Arena.cs
+++ b/JumpRoyale/src/Arena.cs
@@ -694,7 +694,7 @@ public partial class Arena : Node2D
         {
             Jumper jumper = jumpersEntry.Value;
 
-            if (!jumper.PlayerData.Name.Equals(displayName, StringComparison.CurrentCultureIgnoreCase))
+            if (!jumper.PlayerData.Name.Equals(displayName))
             {
                 continue;
             }

--- a/JumpRoyale/src/Arena.cs
+++ b/JumpRoyale/src/Arena.cs
@@ -163,9 +163,10 @@ public partial class Arena : Node2D
 
         int randomCharacterChoice = _rng.RandiRange(1, 18);
 
-        PlayerData playerData = _allPlayerData.Players.TryGetValue(userId, out PlayerData? value)
-            ? value
-            : new PlayerData(hexColor, randomCharacterChoice);
+        if (!_allPlayerData.Players.TryGetValue(userId, out PlayerData? playerData))
+        {
+            playerData = new(hexColor, randomCharacterChoice);
+        }
 
         _allPlayerData.Players[userId] = playerData;
 

--- a/JumpRoyale/src/Commands/ChatCommandParser.cs
+++ b/JumpRoyale/src/Commands/ChatCommandParser.cs
@@ -30,7 +30,7 @@ public class ChatCommandParser
 
     public string?[] ArgumentsAsStrings()
     {
-        return PadList(_arguments, null).ToArray();
+        return [.. PadList(_arguments, null)];
     }
 
     /// <summary>
@@ -45,7 +45,7 @@ public class ChatCommandParser
             select parsedArgument
         ).ToList();
 
-        return PadList(arguments, null).ToArray();
+        return [.. PadList(arguments, null)];
     }
 
     private static int? ParseToNumberOrNull(string test)
@@ -76,7 +76,7 @@ public class ChatCommandParser
 
     private static List<string?> ParseChatMessage(string chatMessage)
     {
-        List<string?> result = new();
+        List<string?> result = [];
 
         // TODO: find a way to capture mixed values, like Hex (e.g. glow BDFF00)
         // Unfortunately, for now, since the only command that uses mixed values is glow, we have
@@ -138,7 +138,7 @@ public class ChatCommandParser
 
     private static List<string?> HandleHexArguments(string chatMessage)
     {
-        List<string?> arguments = new() { "glow" };
+        List<string?> arguments = ["glow"];
 
         string[] split = chatMessage.Split(
             "glow",

--- a/JumpRoyale/src/Commands/CommandMatcher.cs
+++ b/JumpRoyale/src/Commands/CommandMatcher.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
 
 /// <summary>
 /// Provides a set of methods for pattern matching of command names extracted from a chat message.
@@ -14,33 +13,32 @@ using System.Linq;
 /// </remarks>
 public static class CommandMatcher
 {
-    public static readonly ImmutableList<string> CharCommandAliases = ImmutableList.Create("char");
-    public static readonly ImmutableList<string> GlowCommandAliases = ImmutableList.Create("glow");
-    public static readonly ImmutableList<string> JoinCommandAliases = ImmutableList.Create("join");
-    public static readonly ImmutableList<string> JumpCommandAliases = ImmutableList.Create("j", "l", "r", "u");
-    public static readonly ImmutableList<string> UnglowCommandAliases = ImmutableList.Create("unglow");
+    public static readonly ImmutableList<string> CharCommandAliases = ["char"];
+    public static readonly ImmutableList<string> GlowCommandAliases = ["glow"];
+    public static readonly ImmutableList<string> JoinCommandAliases = ["join"];
+    public static readonly ImmutableList<string> JumpCommandAliases = ["j", "l", "r", "u"];
+    public static readonly ImmutableList<string> UnglowCommandAliases = ["unglow"];
 
     static CommandMatcher()
     {
         // Warning: whenever a new alias list is added, add it to this list below! It will automatically
         // expose a list of all commands combined for display and testing purposes
         List<ImmutableList<string>> availableAliases =
-            new()
-            {
-                CharCommandAliases,
-                GlowCommandAliases,
-                JoinCommandAliases,
-                JumpCommandAliases,
-                UnglowCommandAliases,
-            };
-        List<string> allAliases = new();
+        [
+            CharCommandAliases,
+            GlowCommandAliases,
+            JoinCommandAliases,
+            JumpCommandAliases,
+            UnglowCommandAliases,
+        ];
+        List<string> allAliases = [];
 
         foreach (ImmutableList<string> aliases in availableAliases)
         {
-            allAliases.AddRange(aliases.ToArray());
+            allAliases.AddRange([.. aliases]);
         }
 
-        AvailableCommands = ImmutableList.Create(allAliases.ToArray());
+        AvailableCommands = [.. allAliases];
     }
 
     public static ImmutableList<string> AvailableCommands { get; private set; }

--- a/JumpRoyale/src/Commands/JumpCommand.cs
+++ b/JumpRoyale/src/Commands/JumpCommand.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 
 public class JumpCommand
 {
-    private readonly List<string> _fixedAngleDirections = new() { "u", "ll", "lll", "jj", "rr", "jjj", "rrr" };
+    private readonly List<string> _fixedAngleDirections = ["u", "ll", "lll", "jj", "rr", "jjj", "rrr"];
 
     private int _power;
 

--- a/JumpRoyale/src/PlayerData.cs
+++ b/JumpRoyale/src/PlayerData.cs
@@ -1,12 +1,7 @@
 // Note to contributors: do not rename anything in this class without updating the corresponding JSON data on disk.
-public class PlayerData
-{
-    public PlayerData(string glowColor, int characterChoice)
-    {
-        GlowColor = glowColor;
-        CharacterChoice = characterChoice;
-    }
 
+public class PlayerData(string glowColor, int characterChoice)
+{
     public int Num1stPlaceWins { get; set; }
 
     public int Num2ndPlaceWins { get; set; }
@@ -20,9 +15,9 @@ public class PlayerData
     public int TotalHeightAchieved { get; set; }
 
     // Looks like "#RRGGBB"
-    public string GlowColor { get; set; }
+    public string GlowColor { get; set; } = glowColor;
 
-    public int CharacterChoice { get; set; }
+    public int CharacterChoice { get; set; } = characterChoice;
 
     // Note that this can change between games since you can change your name on
     // Twitch, so this is just for convenience of looking at the JSON file and

--- a/JumpRoyale/src/SpriteFrameCreator.cs
+++ b/JumpRoyale/src/SpriteFrameCreator.cs
@@ -9,7 +9,7 @@ public class SpriteFrameCreator
 
     // Map of string to SpriteFrames
     // Keys are animation names
-    private readonly Dictionary<string, SpriteFrames> _allSpriteFrames = new();
+    private readonly Dictionary<string, SpriteFrames> _allSpriteFrames = [];
 
     // Map of animation name to number of frames
     private readonly Dictionary<string, int> _numFramesPerAnimation =
@@ -43,7 +43,7 @@ public class SpriteFrameCreator
     {
         int numCharacters = 3;
         int numClothings = 3;
-        string[] genders = new[] { "m", "f" };
+        string[] genders = ["m", "f"];
 
         foreach (string gender in genders)
         {

--- a/Tests/Commands/ChatCommandDetectionTests.cs
+++ b/Tests/Commands/ChatCommandDetectionTests.cs
@@ -64,25 +64,24 @@ public class ChatCommandDetectionTests
         // want to force the player to type again when something like "lk 30" was sent.
         // Typo-ed Glow will ditch the argument, if no space was provided
         List<string> commandsWithTypos =
-            new()
-            {
-                "chars",
-                "char 3 3",
-                "gloww",
-                "glow uuuuu",
-                "glowf0f",
-                "glow aaa",
-                "llll 234432",
-                "joinerino",
-                "jumperoni 30 50",
-                "uwu 45",
-                "jjjj",
-                "rrrr",
-                "llll",
-                "rrl42",
-                "u u",
-                "u uu7",
-            };
+        [
+            "chars",
+            "char 3 3",
+            "gloww",
+            "glow uuuuu",
+            "glowf0f",
+            "glow aaa",
+            "llll 234432",
+            "joinerino",
+            "jumperoni 30 50",
+            "uwu 45",
+            "jjjj",
+            "rrrr",
+            "llll",
+            "rrl42",
+            "u u",
+            "u uu7",
+        ];
 
         foreach (string command in commandsWithTypos)
         {

--- a/Tests/Commands/ChatCommandParserTest.cs
+++ b/Tests/Commands/ChatCommandParserTest.cs
@@ -9,7 +9,7 @@ public class ChatCommandParserTests
     [Test]
     public void CanExtractCommandName()
     {
-        List<string> chatInput = new() { "j", "l", "u", "r", "l3", "l30 30", "r 30", "u 30 30", "rrrr7890" };
+        List<string> chatInput = ["j", "l", "u", "r", "l3", "l30 30", "r 30", "u 30 30", "rrrr7890"];
 
         foreach (string input in chatInput)
         {
@@ -26,7 +26,7 @@ public class ChatCommandParserTests
     [Test]
     public void CanReturnNothingWhenEmpty()
     {
-        List<string?> chatInput = new() { null, string.Empty };
+        List<string?> chatInput = [null, string.Empty];
 
         foreach (string? input in chatInput)
         {
@@ -47,7 +47,7 @@ public class ChatCommandParserTests
     [Test]
     public void CanHandleGarbageMessage()
     {
-        List<string> chatInput = new() { string.Empty, " ", ";", "!", "[]", "[#@}=]" };
+        List<string> chatInput = [string.Empty, " ", ";", "!", "[]", "[#@}=]"];
 
         foreach (string input in chatInput)
         {
@@ -64,7 +64,7 @@ public class ChatCommandParserTests
     [Test]
     public void CanExtractStringArguments()
     {
-        List<string> commandInputs = new() { "l30 30", "l 30 30" };
+        List<string> commandInputs = ["l30 30", "l 30 30"];
 
         foreach (string input in commandInputs)
         {
@@ -82,7 +82,7 @@ public class ChatCommandParserTests
     [Test]
     public void CanExtractNumericArguments()
     {
-        List<string> commandInputs = new() { "l30 30", "l 30 30" };
+        List<string> commandInputs = ["l30 30", "l 30 30"];
 
         foreach (string input in commandInputs)
         {
@@ -138,12 +138,12 @@ public class ChatCommandParserTests
     [Test]
     public void CanExtractArgumentOfMixedType()
     {
-        List<string> expectedOutputs = new() { "09B0D9", "BDFF00", "123456", "f02", "f02bc6" };
+        List<string> expectedOutputs = ["09B0D9", "BDFF00", "123456", "f02", "f02bc6"];
 
         foreach (string output in expectedOutputs)
         {
             // Just test for both non-space and space
-            List<string> commandInputs = new() { $"glow {output}", $"glow{output}" };
+            List<string> commandInputs = [$"glow {output}", $"glow{output}"];
 
             foreach (string input in commandInputs)
             {
@@ -159,11 +159,11 @@ public class ChatCommandParserTests
     [Test]
     public void CanRejectInvalidGlowColors()
     {
-        List<string> invalidColors = new() { "1234", "90 8da", "ffdd1", "v90909", "8888888", "l", "2" };
+        List<string> invalidColors = ["1234", "90 8da", "ffdd1", "v90909", "8888888", "l", "2"];
 
         foreach (string color in invalidColors)
         {
-            List<string> commandInputs = new() { $"glow {color}", $"glow{color}" };
+            List<string> commandInputs = [$"glow {color}", $"glow{color}"];
 
             foreach (string input in commandInputs)
             {

--- a/Tests/Commands/JumpCommandTests.cs
+++ b/Tests/Commands/JumpCommandTests.cs
@@ -11,7 +11,7 @@ public class JumpCommandTests
     public void CanOmitSpaceInJumpCommands()
     {
         // Reminder, Angle input of 60 to the Left evaluates to 30
-        List<string> commandInputs = new() { "l60 30", "l 60 30" };
+        List<string> commandInputs = ["l60 30", "l 60 30"];
 
         foreach (string input in commandInputs)
         {
@@ -32,7 +32,7 @@ public class JumpCommandTests
     [Test]
     public void CanFallbackToDefaults()
     {
-        List<string> commandInputs = new() { "j", "l", "r", "r r", "u" };
+        List<string> commandInputs = ["j", "l", "r", "r r", "u"];
 
         foreach (string input in commandInputs)
         {
@@ -52,7 +52,7 @@ public class JumpCommandTests
     [Test]
     public void CanAlwaysJumpUpWithAmbiguousParameters()
     {
-        List<string> commandInputs = new() { "u u", "u", "u45", "u 45", "u 70 70", "u 100 90" };
+        List<string> commandInputs = ["u u", "u", "u45", "u 45", "u 70 70", "u 100 90"];
 
         foreach (string input in commandInputs)
         {
@@ -70,7 +70,7 @@ public class JumpCommandTests
     public void CanAdjustPowerOfJumpUp()
     {
         // Mind the angle conversion for the given command! "u" returns 90, because we don't convert it
-        List<string> commandInputs = new() { "u50", "u 50", "u50 50" };
+        List<string> commandInputs = ["u50", "u 50", "u50 50"];
 
         foreach (string input in commandInputs)
         {
@@ -92,7 +92,7 @@ public class JumpCommandTests
     public void CanAdjustPowerOfTypoedJumpUp()
     {
         // Mind the angle conversion for the given command! "u" returns 90, because we don't convert it
-        List<string> commandInputs = new() { "ughk50", "uj 50", "ufjh50 50" };
+        List<string> commandInputs = ["ughk50", "uj 50", "ufjh50 50"];
 
         foreach (string input in commandInputs)
         {
@@ -117,7 +117,7 @@ public class JumpCommandTests
         // "l l 5" will cause the test to fail, because the argument extractor will interpret
         // the first string as command name and the rest will be interpreted as arguments,
         // so the second string will default to "JUMP UP" (90 angle)
-        List<string> commands = new() { "lk5", "rkl-5", "la 5", "jk -5", "l 5 l", "l5 ldfs" };
+        List<string> commands = ["lk5", "rkl-5", "la 5", "jk -5", "l 5 l", "l5 ldfs"];
 
         foreach (string command in commands)
         {
@@ -141,6 +141,6 @@ public class JumpCommandTests
         JumpCommand jump = new(command.Name, arguments[0], arguments[1]);
 
         // Note: arguments are interpreted as Angle/Power values
-        return new(jump, new[] { arguments[0] ?? 0, arguments[1] ?? 100 }, command.Name);
+        return new(jump, [arguments[0] ?? 0, arguments[1] ?? 100], command.Name);
     }
 }


### PR DESCRIPTION
There are some minor readability adjustments in C#12.0 (or QoL, you name it) that were worth switching to, mostly the Collection Expressions. I will briefly explain the changes.

`.editorconfig` one collection expression rule had to be disabled for now, because a fix for "no extra spaces before opening bracket" is in beta release since Dec 2023, doesn't matter, though ¯\\\_(ツ)\_\/¯
I will bump the package once released on NuGet.

---

### Collection Expression changes

All instances of collection initialization were changed:

```diff
- List<string> someList = new();
+ List<string> someList = [];

- List<string> someList = new() { "str1", "str2" };
+ List<string> someList = ["str1", "str2"];

- return someList.ToArray();
+ return [.. someList];
//        ^ C#'s spread
```

More info in [MS Docs - Collection Expressions](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/collection-expressions)

---

- *Prefer a `TryGetValue` call over a Dictionary indexer access guarded by a `ContainsKey` check to avoid double lookup*

```diff
-PlayerData playerData = _allPlayerData.Players.ContainsKey(userId)
-    ? _allPlayerData.Players[userId]
-    : new PlayerData(hexColor, randomCharacterChoice);
+if (!_allPlayerData.Players.TryGetValue(userId, out PlayerData? playerData))
+{
+    playerData = new(hexColor, randomCharacterChoice);
+}
```
The `out` parameter will either contain the indexed object (existing player) or fall into the `if` statement, where it gets a new `PlayerData` object.

---

- Prefer .Equals() when comparing strings with any string operations, like `.ToLower()`, etc.

```diff
-if (jumper.PlayerData.Name.ToLower() != displayName.ToLower())
+if (!jumper.PlayerData.Name.Equals(displayName, StringComparison.CurrentCultureIgnoreCase))
```

This isn't strictly a QoL, but rather a good practice, and since we are using Twitch *display name* (no special characters) as output and we don't do any culture-specific formatting/sorting or globalization, we can just use `CurrentCultureIgnoreCase`. Not like it matters anyway, here we can pick whatever `~IgnoreCase` comparison.

---

### Primary Constructors

This is a big one. When the class constructor is only used to initialize class fields or properties, a `Primary Constructor` can be used instead, which exposes constructor parameters to the entire class to use (it's a parameter, **it's not stored, it's not a class member**).

```diff
- public class PlayerData
- {
-     public PlayerData(string glowColor, int characterChoice)
-    {
-         GlowColor = glowColor;
-         CharacterChoice = characterChoice;
-    }
- 
-    public string GlowColor { get; set; }
-    public int CharacterChoice { get; set; }
- }
+ public class PlayerData(string glowColor, int characterChoice)
+ {
+    public string GlowColor { get; set; } = glowColor;
+    public int CharacterChoice { get; set; } = characterChoice;
+ }
```

It's not really necessary to use them, but when the constructor's body is only used for initialization, it can just be discarded. In general, those parameters should be used only once, e.g. to be accessed inside other class members **OR** to be used as a initializer for fields/properties **OR** to initialize a base class.

More info in [MS Docs](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/tutorials/primary-constructors#create-mutable-state).