### PR TITLE
Fix missing "JumpRoyale" subdirectory in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Sending `char <choice>` in the chat allows you to change your character graphic.
     -   Install [Godot ≥4.2](https://godotengine.org/download/windows/)
     -   Clone this repo
     -   Generate a twitch token for your twitch account: <https://twitchtokengenerator.com/>. You only need the scopes "chat:read" and "chat:edit" for now. Copy the **access token** and set it:
-        -   `cd JumpRoyale`
+        -   `cd JumpRoyale/JumpRoyale`
         -   `dotnet user-secrets set twitch_access_token <your access token>`
         -   `dotnet user-secrets set twitch_channel_name <your channel name>`
     -   Ensure that you have a `GODOT4` environment variable:


### PR DESCRIPTION
This is necessary since the godot project was moved into a sub-directory.