### PR TITLE
Fix `glow` crashing on `random` color, reset unprivileged users name colors

### DIFF
--- a/JumpRoyale/src/Arena.cs
+++ b/JumpRoyale/src/Arena.cs
@@ -196,7 +196,7 @@ public partial class Arena : Node2D
         if (!isPrivileged)
         {
             // Reset the name with default color
-            jumper.SetPlayerName();
+            jumper.SetPlayerName(true);
             jumper.DisableGlow();
         }
 

--- a/JumpRoyale/src/Arena.cs
+++ b/JumpRoyale/src/Arena.cs
@@ -209,6 +209,12 @@ public partial class Arena : Node2D
     {
         string glowColor = userHexColor is not null ? userHexColor : twitchChatHexColor;
 
+        // The player could have sent "random" as his color choice, so we have to translate it to random Hex color
+        if (glowColor.Equals("random", StringComparison.CurrentCultureIgnoreCase))
+        {
+            glowColor = Rng.RandomHex();
+        }
+
         jumper.SetGlow(glowColor);
     }
 

--- a/JumpRoyale/src/Jumper.cs
+++ b/JumpRoyale/src/Jumper.cs
@@ -61,7 +61,8 @@ public partial class Jumper : CharacterBody2D
         // when the player becomes unprivileged after the subscription runs out
         if (forceDefaultColor)
         {
-            PlayerData.NameColor = DefaultColorName;
+            // Note: we are not overwriting the previous color from PlayerData, so the player can have his color back
+            // when privileged again
             colorName = DefaultColorName;
         }
 

--- a/JumpRoyale/src/Jumper.cs
+++ b/JumpRoyale/src/Jumper.cs
@@ -52,13 +52,18 @@ public partial class Jumper : CharacterBody2D
         }
     }
 
-    public void SetPlayerName(string? newColor = null)
+    public void SetPlayerName(bool forceDefaultColor = false)
     {
-        // If no color was specified use Default instead
-        string colorOverride = newColor ?? DefaultColorName;
+        // If JSON data was incomplete, e.g. first run or property was just null (new player), use the default color
+        string colorName = PlayerData.NameColor ?? DefaultColorName;
 
-        // If JSON data was incomplete, e.g. first run or property was just null (new player), use the above override
-        string colorName = PlayerData.NameColor ?? colorOverride;
+        // There can be situations when we would want to force a default color despite the choice, the main reason is
+        // when the player becomes unprivileged after the subscription runs out
+        if (forceDefaultColor)
+        {
+            PlayerData.NameColor = DefaultColorName;
+            colorName = DefaultColorName;
+        }
 
         // Note: ToHTML() excludes alpha component to avoid transparent names
         string colorCode = Color.FromString(colorName, DefaultPlayerNameColor).ToHtml(false);


### PR DESCRIPTION
There was some bad logic in Join command. When user's subscription ran out, it didn't revert back to default, and since we treat `namecolor` as a sub-only command, I guess we have to force the users to use default color, which at the moment is White.

This will not change the previous color the user chose in the game, so whenever he's privileged again, the color automatically change back.

`SetPlayerName` basically had an unused default, because the name is being set through PlayerData, not through this method, so I change it with the following conditions:

- New player: use `white`
- Returning player: use player's choice
  - Choice will be overwritten if requested by `Join` command - unprivileged users join with forced default.