### PR TITLE
Particles adjustment

### DIFF
--- a/JumpRoyale/scenes/Jumper.tscn
+++ b/JumpRoyale/scenes/Jumper.tscn
@@ -92,14 +92,17 @@ script = ExtResource("1_jn4ug")
 [node name="Glow" type="CPUParticles2D" parent="."]
 visible = false
 position = Vector2(0, -14)
-amount = 16
-lifetime = 0.75
+amount = 20
 emission_shape = 2
 emission_sphere_radius = 1.0
+direction = Vector2(0, 1)
 spread = 180.0
 gravity = Vector2(2.08165e-12, 2.08165e-12)
-initial_velocity_min = 34.72
-initial_velocity_max = 34.72
+initial_velocity_min = 70.0
+initial_velocity_max = 70.0
+angular_velocity_max = 360.0
+damping_min = 100.0
+damping_max = 100.0
 angle_max = 360.0
 scale_amount_max = 3.0
 

--- a/JumpRoyale/scenes/Jumper.tscn
+++ b/JumpRoyale/scenes/Jumper.tscn
@@ -95,7 +95,6 @@ position = Vector2(0, -14)
 amount = 20
 emission_shape = 2
 emission_sphere_radius = 1.0
-direction = Vector2(0, 1)
 spread = 180.0
 gravity = Vector2(2.08165e-12, 2.08165e-12)
 initial_velocity_min = 70.0


### PR DESCRIPTION
Adjusted some particles settings after fiddling around.

Old:
![old](https://github.com/AdamLearns/JumpRoyale/assets/7021295/1f689da9-636a-46da-b48a-adfa54d48ef1)

New:
![new](https://github.com/AdamLearns/JumpRoyale/assets/7021295/137d8590-da8f-4be7-b19b-4ec93c9ef59d)

Particles when the jumper moves:
![results](https://github.com/AdamLearns/JumpRoyale/assets/7021295/30b91426-7f18-4ce0-aeb8-691a2d4d7566)

---

Initially, I wanted to make the particles orbit around the jumper:
![orbit](https://github.com/AdamLearns/JumpRoyale/assets/7021295/d17f4d69-ba05-46f6-b356-5e5fc9d2b48c)

But then, this happens when you jump, so I dropped the idea:
![Orbit2](https://github.com/AdamLearns/JumpRoyale/assets/7021295/403307aa-e275-466d-8390-08e5a9cbc631)

You can force the particles to be local to scene to prevent this, but they won't leave the trail as they do now, the particle system moves with the jumper.

It looks a bit weird, not sure how it would look in a real game with many players and in the result screen, but if you decide to try this, change the following:

- Orbit Velocity: Min:0 / Max:1
- Time Scale: 0.5

Who knows, maybe it will look more fun! It's a sub command after all