### PR TITLE
Add jumper spin, rewrite some logic

### DIFF
--- a/JumpRoyale/src/Arena.cs
+++ b/JumpRoyale/src/Arena.cs
@@ -100,6 +100,16 @@ public partial class Arena : Node2D
                 commandHandler.SpawnFakePlayers();
             }
         }
+
+        // Make everyone jump, no exceptions
+        if (Input.IsPhysicalKeyPressed(Key.J))
+        {
+            foreach (Jumper jumper in ActiveJumpers.Instance.AllJumpers())
+            {
+                jumper.RandomJump();
+                jumper.FlashPlayerName();
+            }
+        }
     }
 
     /// <summary>

--- a/JumpRoyale/src/Jumper.cs
+++ b/JumpRoyale/src/Jumper.cs
@@ -209,7 +209,7 @@ public partial class Jumper : CharacterBody2D
     {
         Velocity = !_jumpVelocity.IsEqualApprox(Vector2.Zero) ? _jumpVelocity : Velocity;
 
-        // Flip the sprite base on our x velocity, but only if we recently jumped at a non-zero angle
+        // Flip the sprite based on our x velocity, but only if we recently jumped at a non-zero angle
         if (!Mathf.IsZeroApprox(Velocity.X) && !_lastJumpZeroAngle)
         {
             _animatedSprite2D.FlipH = Velocity.X < 0;

--- a/JumpRoyale/src/Jumper.cs
+++ b/JumpRoyale/src/Jumper.cs
@@ -360,11 +360,11 @@ public partial class Jumper : CharacterBody2D
         // Visualization, caps at J60. Approximately every +100 velocity on the plot is the next 10 angles:
         // https://www.wolframalpha.com/input?i=min%28max%28%284sin%28%28abs%28x%29%2F280%29+%2B+300%29%2B5%29%2C1%29%2C+7%29+%3Bx+from+0+to+700
         float velocity = Math.Abs(Velocity.X);
-        float rotationSpeedFromVelocity = (float)(4 * Math.Sin((velocity / 280) + 300) + 5);
-        float clampedRotation = Math.Clamp(rotationSpeedFromVelocity, 1, 7);
+        float rotationSpeedMultiplier = (float)(4 * Math.Sin((velocity / 280) + 300) + 5);
+        float clampedMultiplier = Math.Clamp(rotationSpeedMultiplier, 1, 7);
 
         // Calculate the rotation factor and flip the value if we are going left (rotating in the right direction)
-        float rotationFactor = 200 * (float)delta * (Velocity.X < 0 ? -1 : 1) * clampedRotation;
+        float rotationFactor = 200 * (float)delta * (Velocity.X < 0 ? -1 : 1) * clampedMultiplier;
 
         _animatedSprite2D.RotationDegrees = IsOnFloor() ? 0 : _animatedSprite2D.RotationDegrees + rotationFactor;
     }

--- a/JumpRoyale/src/Jumper.cs
+++ b/JumpRoyale/src/Jumper.cs
@@ -361,7 +361,7 @@ public partial class Jumper : CharacterBody2D
         // https://www.wolframalpha.com/input?i=min%28max%28%284sin%28%28abs%28x%29%2F280%29+%2B+300%29%2B5%29%2C1%29%2C+7%29+%3Bx+from+0+to+700
         float velocity = Math.Abs(Velocity.X);
         float rotationSpeedFromVelocity = (float)(4 * Math.Sin((velocity / 280) + 300) + 5);
-        float clampedRotation = Math.Clamp(rotationSpeedFromVelocity, 1, 10);
+        float clampedRotation = Math.Clamp(rotationSpeedFromVelocity, 1, 7);
 
         // Calculate the rotation factor and flip the value if we are going left (rotating in the right direction)
         float rotationFactor = 200 * (float)delta * (Velocity.X < 0 ? -1 : 1) * clampedRotation;

--- a/JumpRoyale/src/Jumper.cs
+++ b/JumpRoyale/src/Jumper.cs
@@ -174,15 +174,14 @@ public partial class Jumper : CharacterBody2D
         StopOnFloor();
         ApplyInitialGravity(delta);
         ApplyJumpVelocity();
-
         RotateInAir(delta);
         BounceOffWall();
+        PlayNotGroundedAnimation();
+        UpdateNameTransparency();
 
         _wasOnFloor = IsOnFloor();
         _previousXVelocity = Velocity.X;
 
-        PlayNotGroundedAnimation();
-        UpdateNameTransparency();
         MoveAndSlide();
         StorePosition();
     }

--- a/JumpRoyale/src/Jumper.cs
+++ b/JumpRoyale/src/Jumper.cs
@@ -165,14 +165,6 @@ public partial class Jumper : CharacterBody2D
         _canFadePlayerName = false;
     }
 
-    public void SetColor(string hexColor)
-    {
-        AnimatedSprite2D sprite = GetNode<AnimatedSprite2D>(SpriteNodeName);
-
-        sprite.Modulate = Color.FromHtml(hexColor);
-        sprite.Modulate = new Color(sprite.Modulate.R, sprite.Modulate.G, sprite.Modulate.B, 1f);
-    }
-
     public override void _PhysicsProcess(double delta)
     {
         Vector2 velocity = Velocity;

--- a/JumpRoyale/src/Jumper.cs
+++ b/JumpRoyale/src/Jumper.cs
@@ -356,7 +356,7 @@ public partial class Jumper : CharacterBody2D
         // Formula to automatically calculate the rotation speed based on the character's x jump velocity. The maximum
         // velocity is 700, but it's a bit too fast, so we want to clamp it at around 600. The formula was shortened and
         // tweaked to always output 1 at non-zero angle with low value, with a maximum of 7 at angle of 60, which should
-        // not increase linearly, but a bit slower at the start
+        // not increase linearly, but a bit slower at the start. Assuming the full power jump.
         // Visualization, caps at J60. Approximately every +100 velocity on the plot is the next 10 angles:
         // https://www.wolframalpha.com/input?i=min%28max%28%284sin%28%28abs%28x%29%2F280%29+%2B+300%29%2B5%29%2C1%29%2C+7%29+%3Bx+from+0+to+700
         float velocity = Math.Abs(Velocity.X);

--- a/JumpRoyale/src/Jumper.cs
+++ b/JumpRoyale/src/Jumper.cs
@@ -197,23 +197,16 @@ public partial class Jumper : CharacterBody2D
             _jumpVelocity = Vector2.Zero;
         }
 
-        RotateInAir(delta);
-
-        if (IsOnWall())
-        {
-            velocity.X = _previousXVelocity * -0.75f;
-        }
-
         Velocity = velocity;
 
-        PlayNotGroundedAnimation();
+        RotateInAir(delta);
+        BounceOffWall();
 
         _wasOnFloor = IsOnFloor();
-
-        UpdateNameTransparency();
-
         _previousXVelocity = Velocity.X;
 
+        PlayNotGroundedAnimation();
+        UpdateNameTransparency();
         MoveAndSlide();
         StorePosition();
     }
@@ -273,6 +266,16 @@ public partial class Jumper : CharacterBody2D
     private void SetNameAlpha(float alpha)
     {
         GetNode<RichTextLabel>(NameNodeName).Modulate = new Color(1, 1, 1, alpha);
+    }
+
+    private void BounceOffWall()
+    {
+        if (!IsOnWall())
+        {
+            return;
+        }
+
+        Velocity = new(_previousXVelocity * -0.75f, Velocity.Y);
     }
 
     /// <summary>

--- a/JumpRoyale/src/Jumper.cs
+++ b/JumpRoyale/src/Jumper.cs
@@ -197,6 +197,8 @@ public partial class Jumper : CharacterBody2D
             _jumpVelocity = Vector2.Zero;
         }
 
+        RotateInAir(delta);
+
         if (IsOnWall())
         {
             velocity.X = _previousXVelocity * -0.75f;
@@ -328,5 +330,35 @@ public partial class Jumper : CharacterBody2D
         {
             _animatedSprite2D.Play(JumperAnimations.AnimationLand);
         }
+    }
+
+    /// <summary>
+    /// Causes the character to rotate based on its X velocity, but only at non-zero angles.
+    /// </summary>
+    private void RotateInAir(double delta)
+    {
+        // We don't want to rotate if we just jumped straight up
+        if (_lastJumpZeroAngle)
+        {
+            // Edge case reset when we jump at the very moment we hit the floor and we keep the previous rotation
+            _animatedSprite2D.RotationDegrees = 0;
+
+            return;
+        }
+
+        // Formula to automatically calculate the rotation speed based on the character's x jump velocity. The maximum
+        // velocity is 700, but it's a bit too fast, so we want to clamp it at around 600. The formula was shortened and
+        // tweaked to always output 1 at non-zero angle with low value, with a maximum of 7 at angle of 60, which should
+        // not increase linearly, but a bit slower at the start
+        // Visualization, caps at J60. Approximately every +100 velocity on the plot is the next 10 angles:
+        // https://www.wolframalpha.com/input?i=min%28max%28%284sin%28%28abs%28x%29%2F280%29+%2B+300%29%2B5%29%2C1%29%2C+7%29+%3Bx+from+0+to+700
+        float velocity = Math.Abs(Velocity.X);
+        float rotationSpeedFromVelocity = (float)(4 * Math.Sin((velocity / 280) + 300) + 5);
+        float clampedRotation = Math.Clamp(rotationSpeedFromVelocity, 1, 10);
+
+        // Calculate the rotation factor and flip the value if we are going left (rotating in the right direction)
+        float rotationFactor = 200 * (float)delta * (Velocity.X < 0 ? -1 : 1) * clampedRotation;
+
+        _animatedSprite2D.RotationDegrees = IsOnFloor() ? 0 : _animatedSprite2D.RotationDegrees + rotationFactor;
     }
 }


### PR DESCRIPTION
🤸‍♂️ 💨 

This PR adds the sprite rotation whenever we jump at a non-zero angle. I didn't want it to rotate at constant speed, but to increase non-linearly based on the X velocity, so assuming we jump at full power with `R5`, we will rotate slowly, with `R60` we hit the cap to not make the jumpers spin super fast. The formula is in the code, but the general idea:

Maximum velocity of a `R90` jump is 700, but we rarely even go above 60-70°, so I went with a limit of 600. I made up some random formula that outputs a multiplier of 1-7 applied to the base rotation value (x: Velocity / y: Multiplier):

![img](https://github.com/AdamLearns/JumpRoyale/assets/7021295/6167b529-e26e-4374-8dfb-fde28af0a7eb)

The extra formula wasn't really necessary, but I wanted it to rotate slowly up to like 15°

---

### Other stuff:

_(I forgot I was supposed to separate the following, but well...)_

- 0dc3cc0378b50371a65ed408adca07a82a4ccf15 We had an unused `SetColor` method, maybe it was some old stuff, no idea. It was changing the sprite color
- I noticed there was a condition that was never used with the other `stuckInAir` condition (`justLanded`), removing it didn't even change anything - maybe I don't know the context of that, but the animation is still switching correctly to `Land` when touching the floor 🤔 this also resulted in removing the `_wasOnFloor`, which was the only occurrence
- code in `_PhysicsProcess` was extracted / grouped similarly to what I do in the new code
- reordered methods - I like having built-ins first (if possible) and using `_Ready` for caching components

The `RandomJump` was also never used anywhere, so I added a hotkey `J` that takes all active jumpers and makes them jump in random direction. Useful for testing jumps on the `bots` you add with `B` key. **Launch the game, press `B`, hold `J`** 

> [!Note]
> Note on `null!` component declaration: you can't access nodes through constructor, only when they enter the tree, so they have to be accessed through `_Ready`, which produces a warning, hence the *null forgiving operator* to indicate that fields are initialized at runtime and you are 100% sure they won't be null before they are used, which doesn't require declaring as nullable and performing null checks everywhere. *Kind of* like `declare` inside TypeScript classes where you expose props, but initialize later.

---

### Video:

https://github.com/AdamLearns/JumpRoyale/assets/7021295/f78895f9-f3a4-4105-9b39-b759af3c4256

