### PR TITLE
Add `e` and `i` aliases for `l` and `r`

### DIFF
--- a/JumpRoyale/src/Commands/JumpCommand.cs
+++ b/JumpRoyale/src/Commands/JumpCommand.cs
@@ -4,7 +4,22 @@ using System.Diagnostics.CodeAnalysis;
 
 public class JumpCommand
 {
-    private readonly List<string> _fixedAngleDirections = ["u", "ll", "lll", "jj", "rr", "jjj", "rrr"];
+    private readonly List<string> _fixedAngleDirections = 
+    [
+        "u", 
+        "ll", 
+        "lll", 
+        "jj", 
+        "rr", 
+        "jjj", 
+        "rrr", 
+        "e", 
+        "ee", 
+        "eee", 
+        "i", 
+        "ii", 
+        "iii",
+    ];
 
     private int _power;
 
@@ -59,12 +74,21 @@ public class JumpCommand
         {
             // Predefined set of angles for available jump commands. The pattern matching allows
             // for typos and garbage while still allowing the angle to be changed.
-            string when direction.StartsWith("rrr") || direction.StartsWith("jjj") => 150,
-            string when direction.StartsWith("rr") || direction.StartsWith("jj") => 120,
-            string when direction.StartsWith("lll") => 30,
-            string when direction.StartsWith("ll") => 60,
-            string when direction.StartsWith('j') || direction.StartsWith('r') => Angle + 90,
-            string when direction.StartsWith('l') => 90 - Angle,
+            string when direction.StartsWith("rrr") 
+            || direction.StartsWith("jjj") 
+            || direction.StartsWith("iii") => 150,
+            string when direction.StartsWith("rr") 
+            || direction.StartsWith("jj") 
+            || direction.StartsWith("ii") => 120,
+            string when direction.StartsWith("lll") 
+            || direction.StartsWith("eee") => 30,
+            string when direction.StartsWith("ll") 
+            || direction.StartsWith("ee") => 60,
+            string when direction.StartsWith('j') 
+            || direction.StartsWith('r') 
+            || direction.StartsWith('i') => Angle + 90,
+            string when direction.StartsWith('l') 
+            || direction.StartsWith('e') => 90 - Angle,
             string when direction.StartsWith('u') => 90,
             _ => 90
         };

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Both `angle` and `power` have a default value, so you don't have to type them in
 
 Quick help:
 
--   `l` (aliases: `e`) - jump left, e.g. `l 45` or `e 45` to jump ↖
+-   `l` (alias: `e`) - jump left, e.g. `l 45` or `e 45` to jump ↖
 -   `r` (aliases: `j`, `i`) - jump right, e.g. `j 45` or `r 45` to jump ↗︎
 -   `u` - jump up, **does not require `angle`**, but allows specifying `power` for weaker jumps, e.g. `u 50`
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The only way to play is for Adam to be streaming the game. At that point, you ca
 
 -   `join`: joins the game. Available at any time, although you'll only really stand a chance at winning if you join in the first ~45 seconds. 😉
 
-To jump, you have to send one of the following commands in the chat: `l`, `u`, `r` (alias `j`). Optionally, you can adjust your angle and jump power.
+To jump, you have to send one of the following commands in the chat: `l`, `u`, `r` (see full list aliases below). Optionally, you can adjust your angle and jump power.
 
 Jump commands are currently accepted in the following format:
 
@@ -36,16 +36,16 @@ Both `angle` and `power` have a default value, so you don't have to type them in
 
 Quick help:
 
--   `l` - jump left, e.g. `l 45` to jump ↖
--   `r` or `j` - jump right, e.g. `j 45` or `r 45` to jump ↗︎
+-   `l` (aliases: `e`) - jump left, e.g. `l 45` or `e 45` to jump ↖
+-   `r` (aliases: `j`, `i`) - jump right, e.g. `j 45` or `r 45` to jump ↗︎
 -   `u` - jump up, **does not require `angle`**, but allows specifying `power` for weaker jumps, e.g. `u 50`
 
 There are additional fixed-angle commands used as shortcuts:
 
--   `rrr` or `jjj`: same as `r 60` or `j 60`
--   `rr` or `jj`: same as `r 30` or `j 30`
--   `lll`: same as `l 60`
--   `ll`: same as `l 30`
+-   `rrr`, `jjj`, or `iii`: same as `r 60` or `j 60`
+-   `rr`, `jj`, or `ii`: same as `r 30` or `j 30`
+-   `lll` or `eee`: same as `l 60`
+-   `ll` or `ee`: same as `l 30`
 
 | angle input    | -90 | -45 | 0   | 45  | 90  |
 | -------------- | --- | --- | --- | --- | --- |

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The only way to play is for Adam to be streaming the game. At that point, you ca
 
 -   `join`: joins the game. Available at any time, although you'll only really stand a chance at winning if you join in the first ~45 seconds. 😉
 
-To jump, you have to send one of the following commands in the chat: `l`, `u`, `r` (see full list aliases below). Optionally, you can adjust your angle and jump power.
+To jump, you have to send one of the following commands in the chat: `l`, `u`, `r` (see full list of aliases below). Optionally, you can adjust your angle and jump power.
 
 Jump commands are currently accepted in the following format:
 

--- a/Tests/Commands/JumpCommandTests.cs
+++ b/Tests/Commands/JumpCommandTests.cs
@@ -135,10 +135,14 @@ public class JumpCommandTests
             {
                 { "rrr", 150 },
                 { "jjj", 150 },
+                { "iii", 150 },
                 { "rr", 120 },
                 { "jj", 120 },
+                { "ii", 120 },
                 { "lll", 30 },
+                { "eee", 30 },
                 { "ll", 60 },
+                { "ee", 60 },
                 { "u", 90 },
             };
 


### PR DESCRIPTION
**Describe the pull request**

Added `e` and `i` aliases for `l` and `r` respectively, so that the hand you type the letter with (on a qwerty layout) matches the direction of the letter (i.e. type `e` with your left hand to go left, instead of `l` with your right hand to go left)

**Why**

In order to provide an alternative for people like me who don't want to dedicate the extra mental effort to map the letter L to the right hand, when they want to go Left, and vice versa.

I chose `e` and `i` because they're vacant, don't have alternative meanings (`d` might come off as "down", for example) both use the same finger on each hand (middle finger in this case), and they're easy to reach.

**How**
By lazily editing the `JumpCommand.cs` file, primarily.

**How will these changes benefit Dark?**
It'll be easier for him to play, if he uses a qwerty keyboard.